### PR TITLE
Disable native comp for git-timemachine

### DIFF
--- a/emacs/config.org
+++ b/emacs/config.org
@@ -88,6 +88,7 @@
   (setq native-comp-async-report-warnings-errors 'silent)
   (pixel-scroll-precision-mode 1)
   (setq pixel-scroll-precision-use-momentum t)
+  (setq native-comp-jit-compilation-deny-list '("git-timemachine"))
   :bind (;; Better than default - from /u/zck
          ("M-c" . capitalize-dwim)
          ("M-l" . downcase-dwim)


### PR DESCRIPTION
There was an issue with `python-mode`, `python-ts-mode` and `terraform-mode`

with `git-timemachine`. I found out that when `git-timemachine` was natively compiled it was causing the failures with python, python-ts and terraform modes.

This disabled native compiling of `git-timemachine`.