### PR TITLE
fix: emacs-overlay schedule

### DIFF
--- a/.github/workflows/emacs-overlay.yml
+++ b/.github/workflows/emacs-overlay.yml
@@ -7,8 +7,8 @@ on:
         description: 'Branch used for building and committing updates around emacs-overlay'
         required: true
         type: string
-    schedule:
-      - cron: '30 8 * * *' # Run nightly at 8:30 UTC
+  schedule:
+    - cron: '30 2 * * *' # Run nightly at 2:30 UTC
 env:
   DEVBOX_API_TOKEN: ${{ secrets.DEVBOX_ACCESS_TOKEN }}
 jobs:


### PR DESCRIPTION
The schedule wasn't supposed to be under `workflow_dispatch` but under just `on`.

Change the schedule to 0230 UTC which maybe 0730/0830 CST depending on the time of year.